### PR TITLE
adding an example of how to launch a training job using python api

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -81,6 +81,20 @@ Run the local model:
 python example_local_endpoint.py
 ```
 
+### Launching Training
+Launch training example show how to:
+- Launch a training run using python API on the server.
+
+**NOTE: Before running this example:**
+- Collect a dataset following the example: [Data Collection](#data-collection)
+```
+python example_launch_training.py \
+   --name 'My Training Job' \
+   --algorithm_name 'CNNMLP' \
+   --dataset_name 'Example Dataset'
+```
+For more available argumenst run `python example_launch_training.py --help`
+
 
 ### Server Model Deployment
 The server deployment example shows how to:
@@ -89,7 +103,9 @@ The server deployment example shows how to:
 
 **NOTE: Before running this example:**
 - Collect a dataset following the example: [Data Collection](#data-collection)
-- Go to your [training dashboard ](https://www.neuracore.app/dashboard/training) and start a training run
+- Start a training run by:
+   - Go to your [training dashboard ](https://www.neuracore.app/dashboard/training) and start a training run
+   - Or follow [Launching Training](#launching-training) to start a training run
 - Wait for the training run to finish
 - Go to your [endpoint dashboard ](https://www.neuracore.app/dashboard/endpoints) and start an endpoint. Call it __"MyExampleEndpoint"__
 - Wait for the status to be active

--- a/examples/example_launch_training.py
+++ b/examples/example_launch_training.py
@@ -1,0 +1,97 @@
+import argparse
+
+import neuracore as nc
+
+
+def create_parser():
+    """Create argument parser with parameters."""
+    parser = argparse.ArgumentParser(description="Launching a training job.")
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        default="My Training Job",
+        help="Name of the training job.",
+    )
+    parser.add_argument(
+        "--gpu_type",
+        type=str,
+        default="NVIDIA_L4",
+        help="Type of GPU to use for training.",
+    )
+    parser.add_argument(
+        "--num_gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs to use for training.",
+    )
+    parser.add_argument(
+        "--frequency",
+        type=int,
+        default=50,
+        help="Frequency of training.",
+    )
+    parser.add_argument(
+        "--algorithm_name",
+        type=str,
+        default="CNNMLP",
+        help="Name of the algorithm to use for training.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="Example Dataset",
+        help="Name of the dataset to use for training.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="Batch size for training.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Number of epochs to train for.",
+    )
+    parser.add_argument(
+        "--action_sequence_length",
+        type=int,
+        default=50,
+        help="Prediction horizon.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    nc.login()
+
+    parser = create_parser()
+    args = parser.parse_args()
+    trainig_name = args.name
+    gpu_type = args.gpu_type
+    num_gpus = args.num_gpus
+    frequency = args.frequency
+    algorithm_name = args.algorithm_name
+    dataset_name = args.dataset_name
+    # Here, algorithm specific configs can be added.
+    # Uses default values, if not defined.
+    algorithm_config = {
+        "batch_size": args.batch_size,
+        "epochs": args.epochs,
+        "action_sequence_length": args.action_sequence_length,
+    }
+
+    job_data = nc.start_training_run(
+        name=trainig_name,
+        gpu_type=gpu_type,
+        num_gpus=num_gpus,
+        frequency=frequency,
+        algorithm_name=algorithm_name,
+        dataset_name=dataset_name,
+        algorithm_config=algorithm_config,
+    )
+
+    print("Training job started")
+    print(f"Training job data: {job_data}")

--- a/neuracore/core.py
+++ b/neuracore/core.py
@@ -1,10 +1,15 @@
 import atexit
+import concurrent
+import json
 from typing import Optional
 
 import numpy as np
+import requests
 
+from .auth import get_auth
 from .auth import login as _login
 from .auth import logout as _logout
+from .const import API_URL
 from .dataset import Dataset
 from .endpoint import EndpointPolicy
 from .endpoint import connect_endpoint as _connect_endpoint
@@ -222,6 +227,199 @@ def get_dataset(name: str) -> Dataset:
     _active_dataset = Dataset.get(name)
     _active_dataset_id = _active_dataset.id
     return _active_dataset
+
+
+def _get_algorithms() -> list[dict]:
+    auth = get_auth()
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        org_alg_req = executor.submit(
+            requests.get,
+            f"{API_URL}/algorithms/",
+            headers=auth.get_headers(),
+            params={"shared": False},
+        )
+        shared_alg_req = executor.submit(
+            requests.get,
+            f"{API_URL}/algorithms/",
+            headers=auth.get_headers(),
+            params={"shared": True},
+        )
+        org_alg, shared_alg = org_alg_req.result(), shared_alg_req.result()
+    org_alg.raise_for_status()
+    shared_alg.raise_for_status()
+    return org_alg.json() + shared_alg.json()
+
+
+def start_training_run(
+    name: str,
+    dataset_name: str,
+    algorithm_name: str,
+    algorithm_config: dict[str, any],
+    gpu_type: str,
+    num_gpus: int,
+    frequency: int,
+) -> dict:
+    """
+    Start a new training run.
+
+    Args:
+        name: Name of the training run
+        dataset_name: Name of the dataset to use for training
+        algorithm_name: Name of the algorithm to use for training
+        algorithm_config: Configuration for the algorithm
+        gpu_type: Type of GPU to use for training
+        num_gpus: Number of GPUs to use for training
+        frequency: Frequency of to synced training data to
+    """
+    # Get dataset id
+    dataset_jsons = Dataset._get_datasets()
+    dataset_id = None
+    for dataset_json in dataset_jsons:
+        if dataset_json["name"] == dataset_name:
+            dataset_id = dataset_json["id"]
+            break
+
+    if dataset_id is None:
+        raise ValueError(f"Dataset {dataset_name} not found")
+
+    # Get algorithm id
+    algorithm_jsons = _get_algorithms()
+    algorithm_id = None
+    for algorithm_json in algorithm_jsons:
+        if algorithm_json["name"] == algorithm_name:
+            algorithm_id = algorithm_json["id"]
+            break
+
+    if algorithm_id is None:
+        raise ValueError(f"Algorithm {algorithm_name} not found")
+
+    data = {
+        "name": name,
+        "dataset_id": dataset_id,
+        "algorithm_id": algorithm_id,
+        "algorithm_config": algorithm_config,
+        "gpu_type": gpu_type,
+        "num_gpus": num_gpus,
+        "frequency": str(frequency),
+    }
+
+    auth = get_auth()
+    response = requests.post(
+        f"{API_URL}/training/jobs", headers=auth.get_headers(), data=json.dumps(data)
+    )
+    response.raise_for_status()
+
+    job_data = response.json()
+    return job_data
+
+
+def get_training_job_data(job_id: str) -> dict:
+    """
+    Check if a training job exists and return its status.
+
+    Args:
+        job_id: The ID of the training job.
+    Raises:
+        requests.exceptions.HTTPError: If the api request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+    """
+    auth = get_auth()
+    try:
+        response = requests.get(f"{API_URL}/training/jobs", headers=auth.get_headers())
+        response.raise_for_status()
+
+        job = response.json()
+        my_job = None
+        for job_data in job:
+            if job_data["id"] == job_id:
+                my_job = job_data
+                break
+        if my_job is None:
+            raise ValueError("Job not found")
+        return my_job
+    except Exception as e:
+        raise ValueError(f"Error accessing job: {e}")
+
+
+def get_training_job_status(job_id: str) -> dict:
+    """
+    Check if a training job exists and return its status.
+
+    Args:
+        job_id: The ID of the training job.
+    Raises:
+        requests.exceptions.HTTPError: If the api request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+    """
+    try:
+        job_data = get_training_job_data(job_id)
+        return job_data["status"]
+    except Exception as e:
+        raise ValueError(f"Error accessing job: {e}")
+
+
+def deploy_model(job_id: str, name: str) -> dict:
+    """
+    Deploy a trained model to an endpoint.
+
+    Args:
+        job_id: The ID of the training job.
+        name: The name of the endpoint.
+    Raises:
+        requests.exceptions.HTTPError: If the api request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+    """
+    auth = get_auth()
+    try:
+        response = requests.post(
+            f"{API_URL}/models/deploy",
+            headers=auth.get_headers(),
+            data=json.dumps({"training_id": job_id, "name": name}),
+        )
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        raise ValueError(f"Error deploying model: {e}")
+
+
+def get_endpoint_status(endpoint_id: str) -> dict:
+    """
+    Get the status of an endpoint.
+    Args:
+        endpoint_id: The ID of the endpoint.
+    Raises:
+        requests.exceptions.HTTPError: If the api request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+    """
+    auth = get_auth()
+    try:
+        response = requests.get(
+            f"{API_URL}/models/endpoints/{endpoint_id}", headers=auth.get_headers()
+        )
+        response.raise_for_status()
+        return response.json()["status"]
+    except Exception as e:
+        raise ValueError(f"Error getting endpoint status: {e}")
+
+
+def delete_endpoint(endpoint_id: str) -> None:
+    """
+    Delete an endpoint.
+    Args:
+        endpoint_id: The ID of the endpoint.
+
+    Raises:
+        requests.exceptions.HTTPError: If the api request returns an error code
+        requests.exceptions.RequestException: If there is a problem with the request
+    """
+    auth = get_auth()
+    try:
+        response = requests.delete(
+            f"{API_URL}/models/endpoints/{endpoint_id}", headers=auth.get_headers()
+        )
+        response.raise_for_status()
+    except Exception as e:
+        raise ValueError(f"Error deleting endpoint: {e}")
 
 
 def create_dataset(


### PR DESCRIPTION
- Added some functions to core.py that allow to kick off and monitor training as well as deploy endpoints using python api.
- Included a launch training script in examples that shows how to launch a training job.
- Adjusted the ReadMe to include the ability to launch training using python api.