### PR TITLE
Added support for resurrecting streams from the dead :ghost: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Error message when the wong credentials are provided to `nc-login` 
+- Streaming will resume correctly after network disruptions
 
 
 ## [1.6.0]

--- a/neuracore/core/nc_types.py
+++ b/neuracore/core/nc_types.py
@@ -457,3 +457,9 @@ class Dataset(BaseModel):
     all_data_types: dict[DataType, int] = Field(default_factory=dict)
     common_data_types: dict[DataType, int] = Field(default_factory=dict)
     recording_ids_in_bucket: bool = False
+
+
+class StreamAliveResponse(BaseModel):
+    """Represents the response from asserting a stream is alive."""
+
+    resurrected: bool

--- a/neuracore/core/streaming/recording_state_manager.py
+++ b/neuracore/core/streaming/recording_state_manager.py
@@ -19,7 +19,8 @@ from neuracore.core.auth import Auth, get_auth
 from neuracore.core.config.get_current_org import get_current_org
 from neuracore.core.const import API_URL, REMOTE_RECORDING_TRIGGER_ENABLED
 from neuracore.core.streaming.client_stream.client_stream_manager import (
-    MINIMUM_BACKOFF_LEVEL,
+    MAXIMUM_BACKOFF_TIME_S,
+    MINIMUM_BACKOFF_TIME_S,
 )
 from neuracore.core.streaming.client_stream.models import (
     BaseRecodingUpdatePayload,
@@ -197,9 +198,13 @@ class RecordingStateManager(AsyncIOEventEmitter):
         updates with exponential backoff retry logic. Processes different types
         of recording notifications and updates local state accordingly.
         """
-        backoff = MINIMUM_BACKOFF_LEVEL
+        backoff_time = MINIMUM_BACKOFF_TIME_S
+
         while self.remote_trigger_enabled.is_enabled():
             try:
+                await asyncio.sleep(backoff_time)
+                backoff_time = min(MAXIMUM_BACKOFF_TIME_S, backoff_time * 2)
+
                 org_id = get_current_org()
                 async with sse_client.EventSource(
                     f"{API_URL}/org/{org_id}/recording/notifications",
@@ -207,7 +212,7 @@ class RecordingStateManager(AsyncIOEventEmitter):
                     headers=self.auth.get_headers(),
                     reconnection_time=timedelta(seconds=0.1),
                 ) as event_source:
-                    backoff = max(MINIMUM_BACKOFF_LEVEL, backoff - 1)
+                    backoff_time = max(MINIMUM_BACKOFF_TIME_S, backoff_time / 2)
                     async for event in event_source:
                         if event.type != "data":
                             continue
@@ -240,14 +245,8 @@ class RecordingStateManager(AsyncIOEventEmitter):
                                     is_recording=True, details=recording
                                 )
 
-            except ConnectionError as e:
-                print(f"Connection error: {e}")
-                await asyncio.sleep(2 ^ backoff)
-                backoff += 1
             except Exception as e:
-                print(f"Unexpected error: {e}")
-                await asyncio.sleep(2 ^ backoff)
-                backoff += 1
+                print(f"Recording signalling error: {e}")
 
     def __stop_remote_trigger(self) -> None:
         """Internal method to stop the remote trigger connection."""


### PR DESCRIPTION
Features:
 - Checkes if a stream was killed when reconnected, re-submits tracks if they were dead
 - Reworked the client stream manger to not block when processing singalling messages 
   - Ensured ice events waited untill the remote description is set

Item:
 - [Recover tracks Item](https://trello.com/c/wtUfFT63/263-recover-stream-tracks-after-internet-drops)

Related Prs:
 - [Backend](https://github.com/Neuraco/neuracore_backend/pull/86)