### PR TITLE
fix: not saving single org

### DIFF
--- a/neuracore/core/cli/select_current_org.py
+++ b/neuracore/core/cli/select_current_org.py
@@ -55,9 +55,6 @@ def select_current_org() -> Organization:
                 raise ValueError()
 
             organization = orgs[input_selection - 1]
-            config_manager = get_config_manager()
-            config_manager.config.current_org_id = organization.id
-            config_manager.save_config()
             print(f"You have selected the organization: {organization.name}")
             return organization
         except ValueError:
@@ -81,7 +78,11 @@ def main() -> None:
     try:
         if not auth.is_authenticated:
             auth.login()
-        select_current_org()
+        organization = select_current_org()
+        config_manager = get_config_manager()
+        config_manager.config.current_org_id = organization.id
+        config_manager.save_config()
+
     except AuthenticationError:
         print("Failed to Authenticate, please try again")
     except (OrganizationError, InputError):

--- a/neuracore/core/config/get_current_org.py
+++ b/neuracore/core/config/get_current_org.py
@@ -2,7 +2,7 @@
 
 from neuracore.core.cli.input_lock import user_input_lock
 from neuracore.core.cli.select_current_org import select_current_org
-from neuracore.core.config.config_manager import get_config
+from neuracore.core.config.config_manager import get_config_manager
 from neuracore.core.exceptions import (
     AuthenticationError,
     ConfigError,
@@ -23,10 +23,14 @@ def get_current_org() -> str:
         ConfigError: If there is an error trying to get the config
     """
     with user_input_lock:
-        org_id = get_config().current_org_id
+        config_manager = get_config_manager()
+        org_id = config_manager.config.current_org_id
         if org_id:
             return org_id
         try:
-            return select_current_org().id
+            organization = select_current_org()
+            config_manager.config.current_org_id = organization.id
+            config_manager.save_config()
+            return organization.id
         except (AuthenticationError, OrganizationError, InputError) as e:
             raise ConfigError(f"Failed to select organization: {e}")


### PR DESCRIPTION
Fixes:

 - when a user has just a single organization it was not being saved to the config file
    - Moves the saving logic outside of the select org code to avoid missing any code paths
    
Item:
 - https://trello.com/c/WvwdIHFE/275-bugfix-switching-org-with-a-single-org-not-being-saved

