### PR TITLE
Improved nc-select-org

### DIFF
--- a/neuracore/core/const.py
+++ b/neuracore/core/const.py
@@ -53,4 +53,5 @@ REJECTION_INPUT = {
     "don't",
     "exit",
     "quit",
+    "q",
 }


### PR DESCRIPTION
fix:
 - typo `-org-id` -> `--org-id`

features:
 - Help avalible even if not logged in
 - Better error messages
 - Allows users to quit by typing so